### PR TITLE
Log Exceptions via Jersey ExceptionMapper

### DIFF
--- a/src/main/java/de/tud/plt/r43ples/webservice/ExceptionMapper.java
+++ b/src/main/java/de/tud/plt/r43ples/webservice/ExceptionMapper.java
@@ -1,0 +1,28 @@
+package de.tud.plt.r43ples.webservice;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.log4j.Logger;
+
+@Provider
+public class ExceptionMapper implements
+		javax.ws.rs.ext.ExceptionMapper<Exception> {
+	private static Logger logger = Logger.getLogger(ExceptionMapper.class);
+
+	@Override
+	public Response toResponse(Exception e) {
+		logger.error(e.getMessage(), e);
+
+		Response response;
+		if (e instanceof WebApplicationException) {
+			WebApplicationException webEx = (WebApplicationException) e;
+			response = webEx.getResponse();
+		} else {
+			response = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+					.entity("Internal error").type("text/plain").build();
+		}
+		return response;
+	}
+}

--- a/src/main/java/de/tud/plt/r43ples/webservice/Service.java
+++ b/src/main/java/de/tud/plt/r43ples/webservice/Service.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.http.HttpException;
 import org.apache.log4j.Logger;
@@ -45,7 +44,8 @@ public class Service {
 		ResourceConfig rc = new ResourceConfig()
 				.registerClasses(Endpoint.class)
 				.property(MustacheMvcFeature.TEMPLATE_BASE_PATH, "templates")
-				.register(MustacheMvcFeature.class);
+				.register(MustacheMvcFeature.class)
+				.register(ExceptionMapper.class);
 		server = GrizzlyHttpServerFactory.createHttpServer(BASE_URI, rc);
 		server.getServerConfiguration().addHttpHandler(
 		        new CLStaticHttpHandler(Service.class.getClassLoader(),"webapp/"), "/static/");


### PR DESCRIPTION
Previously uncaught exceptions were not logged by jersey and grizzly only gave a 500 error. Exceptions are now logged via log4j.