### PR TITLE
Remove URLDecoder because query is already decoded.

### DIFF
--- a/src/main/java/de/tud/plt/r43ples/webservice/Endpoint.java
+++ b/src/main/java/de/tud/plt/r43ples/webservice/Endpoint.java
@@ -187,15 +187,8 @@ public class Endpoint {
 			return Response.serverError().status(Response.Status.NOT_ACCEPTABLE).build();
 		}		
 		
-		String sparqlQueryDecoded;
-		try {
-			sparqlQueryDecoded = URLDecoder.decode(sparqlQuery, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-			sparqlQueryDecoded = sparqlQuery;
-		}
-		logger.info("SPARQL GET query (format: "+format+", query: "+sparqlQueryDecoded +")");
-		return sparql(format, sparqlQueryDecoded, revision_information, query_rewriting);
+		logger.info("SPARQL GET query (format: "+format+", query: "+sparqlQuery +")");
+		return sparql(format, sparqlQuery, revision_information, query_rewriting);
 	}
 	
 	


### PR DESCRIPTION
While executing the following query (GET Request)
```
SELECT DISTINCT ?product ?productLabel
WHERE { 
	?product rdfs:label ?productLabel .
    FILTER (<http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer81/Product3837> != ?product)
	<http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer81/Product3837> bsbm:productFeature ?prodFeature .
	?product bsbm:productFeature ?prodFeature .
	<http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer81/Product3837> bsbm:productPropertyNumeric1 ?origProperty1 .
	?product bsbm:productPropertyNumeric1 ?simProperty1 .
	FILTER (?simProperty1 < (?origProperty1   120) && ?simProperty1 > (?origProperty1 - 120))
	<http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer81/Product3837> bsbm:productPropertyNumeric2 ?origProperty2 .
	?product bsbm:productPropertyNumeric2 ?simProperty2 .
	FILTER (?simProperty2 < (?origProperty2   170) && ?simProperty2 > (?origProperty2 - 170))
}
ORDER BY ?productLabel
```
I got the error 
```
04.09.2017 12:34:44 de.tud.plt.r43ples.webservice.ExceptionMapper - Encountered " <INTEGER> "120 "" at line 13, column 51.
```
Adding the line 
```
logger.info("SPARQL GET query (format: "+format+", query: "+sparqlQuery +")");
```
showed that the query was already decoded.